### PR TITLE
Feature/redirection frenzy

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,13 @@
 class HomeController < ApplicationController
   def index
+    if current_user
+      if current_user.is_admin
+        redirect_to questions_path
+      else
+        redirect_to my_profile_path
+      end
+    else
+      redirect_to new_user_session_path
+    end
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,13 +1,10 @@
 class HomeController < ApplicationController
   def index
-    if current_user
-      if current_user.is_admin
-        redirect_to questions_path
-      else
-        redirect_to my_profile_path
-      end
-    else
-      redirect_to new_user_session_path
-    end
+    home_path = if current_user
+                  current_user.is_admin ? questions_path : my_profile_path
+                else
+                  new_user_session_path
+                end
+    redirect_to(home_path)
   end
 end

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,1 +1,0 @@
-%h1.text-danger Sarce Trainer

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -4,7 +4,6 @@
   %p.alert.alert-danger.alert-dismissible{role: 'alert'}= alert
 
 %ul.nav.nav-pills.navbar-fixed-top.well
-  %li{class: active_class(root_path), role: 'presentation'}= link_to 'Accueil', root_path
   - if user_signed_in?
     %li{class: active_class(my_profile_path), role: 'presentation'}= link_to "#{current_user.first_name} #{current_user.last_name}", my_profile_path
     %li{class: active_class(questions_path), role: 'presentation'}= link_to 'Questions', questions_path

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe HomeController do
   describe 'GET index' do
-    it 'returns http success' do
+    it 'redirect to sign in page if there is no current_user' do
       get :index
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:redirect)
     end
   end
 end

--- a/spec/features/admin/users_index_spec.rb
+++ b/spec/features/admin/users_index_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'Users index' do
     scenario 'should forbid the access to the users list' do
       expect(page).to have_content "You're not allowed to access
                                     this area: get out!"
-      expect(page.current_path).to eq root_path
+      expect(page.current_path).to eq(my_profile_path)
     end
   end
 
@@ -21,7 +21,7 @@ RSpec.feature 'Users index' do
 
     scenario 'should allow access to the users list' do
       expect(page).to have_content 'Liste des utilisateurs'
-      expect(page.current_path).to eq admin_users_path
+      expect(page.current_path).to eq(admin_users_path)
     end
   end
 end

--- a/spec/features/sign_up_spec.rb
+++ b/spec/features/sign_up_spec.rb
@@ -2,8 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Sign up' do
   background do
-    visit '/'
-    click_on 'Inscription'
+    visit '/users/sign_up'
 
     fill_in 'user_first_name', with: user.first_name
     fill_in 'user_last_name', with: user.last_name


### PR DESCRIPTION
There is no more real 'home' page

![image](https://cloud.githubusercontent.com/assets/13150097/16193870/cd8f4d4a-36f1-11e6-8e3c-672fa4d55dd0.png)

If no user is signed in, the home page is the sign in page
if a non-admin user is signed in, the home page is the my profile page
if an admin user is signed in, the home page is the questions index page

some specs have been refactored to work with those new redirections