### PR TITLE
feat(Documentation): Add documentation#index view

### DIFF
--- a/app/views/admin/documentations/index.html.haml
+++ b/app/views/admin/documentations/index.html.haml
@@ -1,1 +1,16 @@
-= @documentations.map(&:name)
+%h2.text-center
+  Liste des documents
+  = link_to new_admin_documentation_path do
+    %span.glyphicon.glyphicon-plus
+%table.table.table-striped
+  - @documentations.each do |documentation|
+    %tr
+      %td= documentation.name
+      %td= documentation.short_name
+      %td= documentation.cover_path
+      %td
+        = link_to admin_documentation_path(documentation) do
+          %span.glyphicon.glyphicon-eye-open
+      %td
+        = link_to edit_admin_documentation_path(documentation) do
+          %span.glyphicon.glyphicon-pencil


### PR DESCRIPTION
Add table that display list of documentations
Add link to documentation#show
Add link to documentation#edit

![documentation index](https://cloud.githubusercontent.com/assets/18015363/16226120/4152be02-37aa-11e6-8348-eca4ce510c5f.png)

Related to issue #81