### PR TITLE
feat(Documentation): Add documentation#show view

### DIFF
--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -9,6 +9,7 @@ body {
   border-color: #ebccd1;
  }
 
+
 .navbar-fixed-top {
  padding-left: 1.875rem;
  padding-top: 1.875rem;
@@ -35,4 +36,10 @@ body {
  .glyphicon-plus {
    padding-left: 10px;
    font-size: 20px;
+ }
+
+ .title {
+   font-size: 2rem;
+   padding-bottom: 1rem;
+   font-weight: bold;
  }

--- a/app/views/admin/documentations/show.html.haml
+++ b/app/views/admin/documentations/show.html.haml
@@ -1,1 +1,12 @@
-= @documentation.name
+= link_to admin_documentations_path do
+  %span.glyphicon.glyphicon-circle-arrow-left.lead
+.title
+  = @documentation.name
+%table.table.table-striped
+  %thead
+    %tr.info
+      %th Abbréviation
+      %th Couverture
+      %tr
+        %td= @documentation.short_name
+        %td= @documentation.cover_path


### PR DESCRIPTION
Add table to display the documentation
Add css for customize the title

![documentation_show](https://cloud.githubusercontent.com/assets/18015363/16230638/d3755e44-37c2-11e6-8580-b4226bbb0a44.png)

Related to issue #83 