### PR TITLE
refactor(documentations): pluck cover_path in controller

### DIFF
--- a/app/controllers/admin/documentations_controller.rb
+++ b/app/controllers/admin/documentations_controller.rb
@@ -1,5 +1,6 @@
 class Admin::DocumentationsController < AdminController
   before_action :assign_documentation, only: %i(show edit update destroy)
+  before_action :assign_documentations_cover_path, only: %i(new edit)
 
   def index
     @documentations = Documentation.all
@@ -48,5 +49,9 @@ class Admin::DocumentationsController < AdminController
 
   def assign_documentation
     @documentation = Documentation.find(params[:id])
+  end
+
+  def assign_documentations_cover_path
+    @documentations_cover_path = Documentation.pluck(:cover_path)
   end
 end

--- a/app/controllers/my_profiles_controller.rb
+++ b/app/controllers/my_profiles_controller.rb
@@ -1,5 +1,4 @@
 class MyProfilesController < ApplicationController
-
   def show
     @me = current_user
     @rank = Rank.const_get(:RANKS)[@me.rank.to_sym]

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,5 +1,6 @@
 class QuestionsController < ApplicationController
   before_action :assign_question, only: %i(show edit update destroy)
+  before_action :assign_documentations_name_id, only: %i(new edit)
 
   def index
     @questions = Question.all.decorate
@@ -9,7 +10,6 @@ class QuestionsController < ApplicationController
   end
 
   def new
-    @documentations = Documentation.all.pluck(:name, :id)
     @question = Question.new.decorate
   end
 
@@ -24,7 +24,6 @@ class QuestionsController < ApplicationController
   end
 
   def edit
-    @documentations = Documentation.all.pluck(:name, :id)
   end
 
   def update
@@ -41,17 +40,21 @@ class QuestionsController < ApplicationController
     redirect_to questions_path,
                 notice: 'The question was destroyed successfully!'
   end
-end
 
-private
+  private
 
-def question_params
-  params.require(:question).permit(
-    :body, { answers: [] }, { correct_answers: [] }, :explanation,
-    :documentation_id, :answer_counter, :positive_rates, :negative_rates
-  )
-end
+  def question_params
+    params.require(:question).permit(
+      :body, { answers: [] }, { correct_answers: [] }, :explanation,
+      :documentation_id, :answer_counter, :positive_rates, :negative_rates
+    )
+  end
 
-def assign_question
-  @question = Question.find(params[:id]).decorate
+  def assign_question
+    @question = Question.find(params[:id]).decorate
+  end
+
+  def assign_documentations_name_id
+    @documentations = Documentation.pluck(:name, :id)
+  end
 end

--- a/app/views/admin/documentations/_form.html.haml
+++ b/app/views/admin/documentations/_form.html.haml
@@ -7,5 +7,5 @@
   = f.text_field :short_name, class: 'form-control', id: 'Abbréviation', required: true
 .field
   %h4= f.label 'Couverture'
-  = f.select(:cover_path, options_for_select(Documentation.all.map { |d| [d.cover_path] }), {}, {class: 'form form-group form-control'})
+  = f.select(:cover_path, options_for_select(@documentations_cover_path), {}, {class: 'form form-group form-control'})
   = f.submit 'Valider', class: 'btn btn-primary'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,6 @@
 Rails.application.configure do
-  # Settings specified here will take precedence over those in config/application.rb.
+  # Settings specified here will take precedence over those in
+  # config/application.rb.
 
   # Code is not reloaded between requests.
   config.cache_classes = true
@@ -25,43 +26,21 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
-  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
-
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
-
-  # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
-  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
-
-  # Action Cable endpoint configuration
-  # config.action_cable.url = 'wss://example.com/cable'
-  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
-
-  # Don't mount Action Cable in the main server process.
-  # config.action_cable.mount_path = nil
-
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
-
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
-  # Use a real queuing backend for Active Job (and separate queues per environment)
+  # Use a real queuing backend for Active Job
+  # (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "sarce-trainer-admin_#{Rails.env}"
   config.action_mailer.perform_caching = false
-
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
@@ -74,10 +53,8 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
 
   # Use a different logger for distributed setups.
-  # require 'syslog/logger'
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger = ActiveSupport::TaggedLogging.new(logger)
@@ -85,4 +62,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  Rails.application.routes.default_url_options[:host] =
+    'sarce-trainer-admin.herokuapp.com'
 end


### PR DESCRIPTION
- Instead of request Documentation on the view use a method pluck cover_path in the controller

- Add pluck_cover_path_documentation method in documentations controler and add it in before_action
- Delete all.pluck on questions controller replace by pluck
- Add pluck_name_id_documentation method  in questions controller and add it in before_action

Related to issue #127 