### PR TITLE
Display errors on forms

### DIFF
--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -9,6 +9,11 @@ body {
   border-color: #ebccd1;
  }
 
+ #form_errors_explanations {
+   color: #a94442;
+   background-color: #f2dede;
+   border-color: #ebccd1;
+  }
 
 .navbar-fixed-top {
  padding-left: 1.875rem;

--- a/app/views/admin/daily_questions/_form.html.haml
+++ b/app/views/admin/daily_questions/_form.html.haml
@@ -1,3 +1,4 @@
+= render('layouts/forms/errors', model_with_errors: @daily_question) if @daily_question.errors.any?
 .field
   %h4= f.label 'Question'
   = f.text_field :question_id, class: 'form-control', id: 'Question', required: true

--- a/app/views/admin/daily_questions/edit.html.haml
+++ b/app/views/admin/daily_questions/edit.html.haml
@@ -1,4 +1,3 @@
 %h2.text-center Modifier la question du jour
-= @daily_question.errors.full_messages.to_sentence if @daily_question.errors.any?
 = form_for @daily_question, url: {action: "update"} do |f|
   = render partial:  'form', locals: { f: f }

--- a/app/views/admin/daily_questions/new.html.haml
+++ b/app/views/admin/daily_questions/new.html.haml
@@ -1,4 +1,3 @@
 %h2.text-center Nouvelle question du jour
-= @daily_question.errors.full_messages.to_sentence if @daily_question.errors.any?
 = form_for @daily_question, url: {action: "create"} do |f|
   = render partial: 'form', locals: { f: f }

--- a/app/views/admin/documentations/_form.html.haml
+++ b/app/views/admin/documentations/_form.html.haml
@@ -1,4 +1,5 @@
 -# Todo (Semia) fix default value for edit in select cover_path
+= render('layouts/forms/errors', model_with_errors: @documentation) if @documentation.errors.any?
 .field
   %h4= f.label 'Nom'
   = f.text_field :name, class: 'form-control', id: 'Nom', required: true, autofocus: true

--- a/app/views/admin/documentations/edit.html.haml
+++ b/app/views/admin/documentations/edit.html.haml
@@ -1,4 +1,3 @@
 %h2.text-center Modifier la documentation
-= @documentation.errors.full_messages.to_sentence if @documentation.errors.any?
 = form_for @documentation, url: {action: "update"} do |f|
     = render partial:  'form', locals: { f: f }

--- a/app/views/admin/documentations/new.html.haml
+++ b/app/views/admin/documentations/new.html.haml
@@ -1,4 +1,3 @@
 %h2.text-center Nouvelle Documentation
-= @documentation.errors.full_messages.to_sentence if @documentation.errors.any?
 = form_for @documentation, url: {action: "create"} do |f|
   = render partial:  'form', locals: { f: f }

--- a/app/views/admin/users/edit.html.haml
+++ b/app/views/admin/users/edit.html.haml
@@ -1,4 +1,5 @@
 %h2.text-center Modifier l'utilisateur
+= render('layouts/forms/errors', model_with_errors: @user) if @user.errors.any?
 = form_for(@user, url: admin_user_path(@user)) do |f|
   .field
     %h4= f.label :first_name

--- a/app/views/devise/registrations/_form.html.haml
+++ b/app/views/devise/registrations/_form.html.haml
@@ -1,4 +1,4 @@
-= devise_error_messages!
+= render('layouts/forms/errors', model_with_errors: @user) if @user.errors.any?
 .field
   %h4= f.label :first_name
   = f.text_field :first_name, class: 'form-control' , autofocus: true

--- a/app/views/layouts/forms/_errors.html.haml
+++ b/app/views/layouts/forms/_errors.html.haml
@@ -1,0 +1,5 @@
+#form_errors_explanations
+  %h2= t('forms.errors.header')
+  %ul
+    - model_with_errors.errors.each do |error|
+      %li error.message

--- a/app/views/layouts/forms/_errors.html.haml
+++ b/app/views/layouts/forms/_errors.html.haml
@@ -1,5 +1,5 @@
 #form_errors_explanations
   %h2= t('forms.errors.header')
   %ul
-    - model_with_errors.errors.each do |error|
-      %li error.message
+    - model_with_errors.errors.full_messages.each do |message|
+      %li= message

--- a/app/views/questions/edit.html.haml
+++ b/app/views/questions/edit.html.haml
@@ -1,6 +1,6 @@
 -# todo : see if it's possible to refactor with a partial
 %h2.text-center Modifier Question
-= @question.errors.full_messages.to_sentence if @question.errors.any?
+= render('layouts/forms/errors', model_with_errors: @question) if @question.errors.any?
 = form_for @question, url: {action: 'update'} do |f|
   .field
     %h4= f.label 'Intitulé'

--- a/app/views/questions/new.html.haml
+++ b/app/views/questions/new.html.haml
@@ -1,6 +1,6 @@
 -# todo : see if it's possible to refactor with a partial
 %h2.text-center Nouvelle Question
-= @question.errors.full_messages.to_sentence if @question.errors.any?
+= render('layouts/forms/errors', model_with_errors: @question) if @question.errors.any?
 = form_for @question, url: {action: "create"} do |f|
   .field
     %h4= f.label 'Intitulé'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -30,6 +30,9 @@ fr:
               required: avec un numéro
     models:
       user: Utilisateur
+  forms:
+    errors:
+      header: 'Il y a des erreurs :'
   devise:
     confirmations:
       confirmed: Votre compte a été confirmé avec succès.


### PR DESCRIPTION
- In order to have in all forms an error explanation

- Implement it in layouts/forms
- Use it in all forms

![form_errors_explanation](https://cloud.githubusercontent.com/assets/18015363/16588605/0215c1d6-42d0-11e6-930d-179865d34c7c.png)

Related to issue #136 
